### PR TITLE
SCHED-16: ILP model now has variables to set / determine at what time slots observations are scheduled.

### DIFF
--- a/ilp_solver/__init__.py
+++ b/ilp_solver/__init__.py
@@ -2,11 +2,12 @@
 # By Sebastian Raaphorst, 2020.
 
 # Load Gurobi if possible, and otherwise fall back on CBC.
-try:
-    import gurobipy
-    from ilp_solver.gurobi_solver import *
-    # This will throw an exception if we do not have an active license.
-    m = Model()
-except gurobipy.GurobiError:
-    from ilp_solver.cbc_solver import *
-# from ilp_solver.cbc_solver import *
+# try:
+#     import gurobipy
+#     from ilp_solver.gurobi_solver import *
+#     # This will throw an exception if we do not have an active license.
+#     m = Model()
+# except gurobipy.GurobiError:
+#     from ilp_solver.cbc_solver import *
+
+from ilp_solver.cbc_solver import *

--- a/ilp_solver/__init__.py
+++ b/ilp_solver/__init__.py
@@ -2,12 +2,12 @@
 # By Sebastian Raaphorst, 2020.
 
 # Load Gurobi if possible, and otherwise fall back on CBC.
-# try:
-#     import gurobipy
-#     from ilp_solver.gurobi_solver import *
-#     # This will throw an exception if we do not have an active license.
-#     m = Model()
-# except gurobipy.GurobiError:
-#     from ilp_solver.cbc_solver import *
+try:
+    import gurobipy
+    from ilp_solver.gurobi_solver import *
+    # This will throw an exception if we do not have an active license.
+    m = Model()
+except gurobipy.GurobiError:
+    from ilp_solver.cbc_solver import *
 
-from ilp_solver.cbc_solver import *
+# from ilp_solver.cbc_solver import *

--- a/ilp_solver/cbc_solver.py
+++ b/ilp_solver/cbc_solver.py
@@ -58,7 +58,7 @@ def ilp_scheduler(time_slots: TimeSlots, observations: List[Observation]) -> Tup
 
     # *** TIME SLOT SCHEDULE VARIABLES: FOR AND / OR ***
     # y_slot[obs_id] = -1 if obs_id is not scheduled, and the time slot at which it is scheduled otherwise.
-    # GRB.INTEGER is lower-bound constrained to 0.0 by default so give it a lower bound of -1.
+    # CBC solver needs hard bounds for IntVars, so give it -1 (unscheduled) to total_time_slots (last possible slot).
     y_slot = [solver.IntVar(-1, time_slots.total_time_slots, f'y_slot_{obs.idx}') for obs in observations]
 
     for obs in observations:

--- a/ilp_solver/cbc_solver.py
+++ b/ilp_solver/cbc_solver.py
@@ -56,6 +56,17 @@ def ilp_scheduler(time_slots: TimeSlots, observations: List[Observation]) -> Tup
         expression = - 1 * y_sched[obs.idx] + y_site_sched[obs.idx][Site.GS] + y_site_sched[obs.idx][Site.GN] == 0
         solver.Add(expression)
 
+    # *** TIME SLOT SCHEDULE VARIABLES: FOR AND / OR ***
+    # y_slot[obs_id] = -1 if obs_id is not scheduled, and the time slot at which it is scheduled otherwise.
+    # GRB.INTEGER is lower-bound constrained to 0.0 by default so give it a lower bound of -1.
+    y_slot = [solver.IntVar(-1, time_slots.total_time_slots, f'y_slot_{obs.idx}') for obs in observations]
+
+    for obs in observations:
+        expression = y_slot[obs.idx] + 1 - sum([(start_slot_idx + 1) * y[obs.idx][start_slot_idx]
+                                            for start_slot_idx in obs.start_slots]) == 0
+        solver.Add(expression)
+
+
     # *** CONSTRAINT TYPE 1 ***
     # First, no observation should be scheduled for more than one start.
     for obs in observations:
@@ -115,6 +126,11 @@ def ilp_scheduler(time_slots: TimeSlots, observations: List[Observation]) -> Tup
         for site in {Site.GS, Site.GN}:
             if y_site_sched[obs.idx][site].solution_value() == 1:
                 print(f'Observation {obs.idx} {obs.name} scheduled at site {Site(site).name}')
+
+    for obs in observations:
+        if y_slot[obs.idx].solution_value() >= 0.0:
+            print(f'Observation {obs.idx} {obs.name} scheduled at time slot {int(y_slot[obs.idx].solution_value())}')
+
     # Iterate over each timeslot index and see if an observation has been scheduled for it.
     final_schedule = [None] * time_slots.total_time_slots
     for time_slot_idx in range(time_slots.total_time_slots):


### PR DESCRIPTION
The `y_slot[obs_idx]` variables determine at what time slot index the observation at `obs_idx` is scheduled, if at all.
If it is not scheduled, `y_slot[obs_idx]` will have a negative value. If it is scheduled, it will contain the index of the time slot at which the observation is scheduled.

You can force observation `obs_idx` to be scheduled at time slot `time_slot_idx` by adding a constraint:
`y_slot[obs_idx] = time_slot_idx`
provided that `time_slot_idx` is a candidate start slot for observation `obs_idx`.